### PR TITLE
Match parent object's layer.

### DIFF
--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Extensions/GameObjectExtensions.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Extensions/GameObjectExtensions.cs
@@ -94,6 +94,7 @@ namespace SuperTiled2Unity.Editor
 
             child.name = name;
             child.transform.SetParent(go.transform, false);
+            child.layer = go.layer;
         }
 
         // Creates a new object, attached to the parent, with a specialized layer component


### PR DESCRIPTION
TRS, CF, tile, and collider objects within an entity's hierarchy haven't been inheriting the same layer value. This makes sure that children of these heirarchies end up with the same layer assigned.