### PR TITLE
Remove unneeded usings

### DIFF
--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/AssetTypes/SuperAsset.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/AssetTypes/SuperAsset.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using UnityEditor.Experimental.AssetImporters;
 using UnityEngine;
 

--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/AssetTypes/SuperAssetMap.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/AssetTypes/SuperAssetMap.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace SuperTiled2Unity.Editor
+﻿namespace SuperTiled2Unity.Editor
 {
     public class SuperAssetMap : SuperAsset
     {

--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/AssetTypes/SuperAssetSettings.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/AssetTypes/SuperAssetSettings.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace SuperTiled2Unity.Editor
+﻿namespace SuperTiled2Unity.Editor
 {
     // Used to tag assets specific to SuperTiled2Unity
     public class SuperAssetSettings : SuperAsset

--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/AssetTypes/SuperAssetTemplate.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/AssetTypes/SuperAssetTemplate.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace SuperTiled2Unity.Editor
+﻿namespace SuperTiled2Unity.Editor
 {
     // Used to tag assets specific to SuperTiled2Unity
     public class SuperAssetTemplate : SuperAsset

--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/AssetTypes/SuperAssetTileset.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/AssetTypes/SuperAssetTileset.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace SuperTiled2Unity.Editor
+﻿namespace SuperTiled2Unity.Editor
 {
     public class SuperAssetTileset : SuperAsset
     {

--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Attributes/AutoCustomTmxImporterAttribute.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Attributes/AutoCustomTmxImporterAttribute.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
-using System.Text;
 
 namespace SuperTiled2Unity.Editor
 {

--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Collision/CollisionBuilder.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Collision/CollisionBuilder.cs
@@ -1,8 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
-using UnityEngine.Assertions;
-using UnityEngine.Tilemaps;
 
 namespace SuperTiled2Unity.Editor
 {

--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Collision/CollisionClipperKey.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Collision/CollisionClipperKey.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace SuperTiled2Unity.Editor
 {

--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Collision/Geometry/ComposeConvexPolygons.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Collision/Geometry/ComposeConvexPolygons.cs
@@ -1,8 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics;
+﻿using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using UnityEngine;
 
 namespace SuperTiled2Unity.Editor.Geometry

--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Collision/Geometry/CompositionPolygon.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Collision/Geometry/CompositionPolygon.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-using System.Text;
+﻿using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Assertions;
 

--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Collision/Geometry/Math.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Collision/Geometry/Math.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using UnityEngine;
+﻿using UnityEngine;
 
 namespace SuperTiled2Unity.Editor.Geometry
 {

--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Collision/Geometry/PolygonEdge.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Collision/Geometry/PolygonEdge.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using UnityEngine;
-using UnityEngine.Assertions;
+﻿using UnityEngine;
 
 namespace SuperTiled2Unity.Editor.Geometry
 {

--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Collision/Geometry/PolygonEdgeGroup.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Collision/Geometry/PolygonEdgeGroup.cs
@@ -1,7 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using UnityEngine;
 
 namespace SuperTiled2Unity.Editor.Geometry

--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Collision/Geometry/Triangulator.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Collision/Geometry/Triangulator.cs
@@ -1,7 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using SuperTiled2Unity.Editor.LibTessDotNet;
 using UnityEngine;
 

--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Collision/TilePolygon.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Collision/TilePolygon.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using UnityEngine;
+﻿using UnityEngine;
 
 namespace SuperTiled2Unity.Editor
 {

--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Collision/TilePolygonCollection.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Collision/TilePolygonCollection.cs
@@ -1,7 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using UnityEngine;
 
 namespace SuperTiled2Unity.Editor

--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/CustomEditors/ColliderGizmos.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/CustomEditors/ColliderGizmos.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using UnityEditor;
 using UnityEngine;
 

--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/CustomEditors/SuperColliderComponentEditor.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/CustomEditors/SuperColliderComponentEditor.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using UnityEngine;
-using UnityEditor;
+﻿using UnityEditor;
 
 namespace SuperTiled2Unity.Editor
 {

--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/CustomImporters/CustomTmxImporter.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/CustomImporters/CustomTmxImporter.cs
@@ -1,13 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Linq;
-using System.Text;
-using SuperTiled2Unity;
-using SuperTiled2Unity.Editor;
-using UnityEngine;
-
-namespace SuperTiled2Unity.Editor
+﻿namespace SuperTiled2Unity.Editor
 {
     public class TmxAssetImportedArgs
     {

--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Extensions/ByteExtensions.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Extensions/ByteExtensions.cs
@@ -1,10 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
-using System.Linq;
-using System.Text;
-using UnityEngine;
 
 namespace SuperTiled2Unity.Editor
 {

--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Extensions/CollisionObjectExtensions.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Extensions/CollisionObjectExtensions.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using UnityEngine;
+﻿using UnityEngine;
 using SuperTiled2Unity.Editor.Geometry;
 
 namespace SuperTiled2Unity.Editor

--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Extensions/CustomPropertyExtensions.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Extensions/CustomPropertyExtensions.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using UnityEngine;
 
 namespace SuperTiled2Unity.Editor
 {

--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Extensions/RectUtil.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Extensions/RectUtil.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using UnityEngine;
+﻿using UnityEngine;
 
 namespace SuperTiled2Unity.Editor
 {

--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Extensions/StreamExtensions.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Extensions/StreamExtensions.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
+﻿using System.IO;
 
 namespace SuperTiled2Unity.Editor
 {

--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Extensions/StringExtensions.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Extensions/StringExtensions.cs
@@ -1,10 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.Linq;
-using System.Text;
 using UnityEngine;
-using UnityEngine.Assertions;
 
 namespace SuperTiled2Unity.Editor
 {

--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Extensions/SuperTileExtensions.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Extensions/SuperTileExtensions.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using UnityEngine;
+﻿using UnityEngine;
 using UnityEngine.Assertions;
 
 namespace SuperTiled2Unity.Editor

--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Extensions/Texture2DExtensions.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Extensions/Texture2DExtensions.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using UnityEngine;
+﻿using UnityEngine;
 
 namespace SuperTiled2Unity.Editor
 {

--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Extensions/TypeExtensions.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Extensions/TypeExtensions.cs
@@ -1,8 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.ComponentModel;
-using System.Linq;
-using System.Text;
 
 namespace SuperTiled2Unity.Editor
 {

--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/GUI/GuiScopedBackgroundColor.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/GUI/GuiScopedBackgroundColor.cs
@@ -1,9 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using UnityEngine;
-using UnityEditor;
 
 namespace SuperTiled2Unity.Editor
 {

--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/GUI/GuiScopedIndent.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/GUI/GuiScopedIndent.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using UnityEditor;
 
 namespace SuperTiled2Unity.Editor

--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Helpers/ChDir.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Helpers/ChDir.cs
@@ -1,8 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
 
 namespace SuperTiled2Unity.Editor
 {

--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Helpers/ReadOnlyPropertyDrawer.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Helpers/ReadOnlyPropertyDrawer.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using SuperTiled2Unity;
-using UnityEngine;
+﻿using UnityEngine;
 using UnityEditor;
 
 

--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Helpers/UniqueNameifier.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Helpers/UniqueNameifier.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 
 namespace SuperTiled2Unity.Editor
 {

--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Importers/SuperImporter.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Importers/SuperImporter.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
 using System.Xml;
 using UnityEditor;
 using UnityEditor.Experimental.AssetImporters;

--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Importers/SuperImporterEditor.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Importers/SuperImporterEditor.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
+﻿using System.IO;
 using System.Linq;
 using System.Text;
 using UnityEditor;

--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Importers/TiledAssetImporterEditor.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Importers/TiledAssetImporterEditor.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using UnityEditor;
-using UnityEditor.Experimental.AssetImporters;
+﻿using UnityEditor;
 using UnityEngine;
 using UnityEngine.Assertions;
 

--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Importers/TmxAssetImporter.GroupLayer.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Importers/TmxAssetImporter.GroupLayer.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Xml.Linq;
+﻿using System.Xml.Linq;
 using UnityEngine;
 
 namespace SuperTiled2Unity.Editor

--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Importers/TmxAssetImporter.ImageLayer.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Importers/TmxAssetImporter.ImageLayer.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Xml.Linq;
 using UnityEngine;
 using UnityEngine.Assertions;

--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Importers/TmxAssetImporterEditor.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Importers/TmxAssetImporterEditor.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
-using System.Text;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.Assertions;

--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Importers/TsxAssetImporterEditor.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Importers/TsxAssetImporterEditor.cs
@@ -1,5 +1,4 @@
-﻿using System.Linq;
-using UnityEditor;
+﻿using UnityEditor;
 using UnityEditor.AnimatedValues;
 using UnityEngine;
 using UnityEngine.Assertions;

--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Importers/TxAssetImporter.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Importers/TxAssetImporter.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Xml.Linq;
-using UnityEditor;
+﻿using System.Xml.Linq;
 using UnityEditor.Experimental.AssetImporters;
 using UnityEngine;
 using UnityEngine.Assertions;

--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Importers/TxAssetImporterEditor.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Importers/TxAssetImporterEditor.cs
@@ -1,12 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Xml.Linq;
+﻿using System.Xml.Linq;
 using UnityEditor;
-using UnityEditor.Experimental.AssetImporters;
 using UnityEngine;
-using UnityEngine.Assertions;
 
 namespace SuperTiled2Unity.Editor
 {

--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Loaders/CustomPropertyLoader.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Loaders/CustomPropertyLoader.cs
@@ -1,9 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using System.Collections.Generic;
 using System.Xml.Linq;
-using UnityEngine;
 
 namespace SuperTiled2Unity.Editor
 {

--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Math/ColliderFactory.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Math/ColliderFactory.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using UnityEngine;
+﻿using UnityEngine;
 
 namespace SuperTiled2Unity.Editor
 {

--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Math/ColliderFactoryIsometric.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Math/ColliderFactoryIsometric.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using UnityEngine;
 
 namespace SuperTiled2Unity.Editor

--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Math/PolygonUtils.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Math/PolygonUtils.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using System.Collections.Generic;
 using UnityEngine;
 
 namespace SuperTiled2Unity.Editor

--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Postprocessors/TiledAssetDependencies.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Postprocessors/TiledAssetDependencies.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using UnityEditor;
 
 namespace SuperTiled2Unity.Editor

--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Properties/CustomObjectType.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Properties/CustomObjectType.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using UnityEngine;
 
 namespace SuperTiled2Unity.Editor

--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Settings/CustomPropertiesWindow.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Settings/CustomPropertiesWindow.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Linq;
 using UnityEditor;
 using UnityEngine;
 

--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Settings/SuperIcons.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Settings/SuperIcons.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using UnityEngine;
+﻿using UnityEngine;
 
 namespace SuperTiled2Unity.Editor
 {

--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Settings/SuperSettingsImporterEditor.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Settings/SuperSettingsImporterEditor.cs
@@ -1,11 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using UnityEditor;
+﻿using UnityEditor;
 using UnityEditor.Experimental.AssetImporters;
 using UnityEngine;
-using UnityEngine.Assertions;
 
 namespace SuperTiled2Unity.Editor
 {

--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/ThirdParty/LibTessDotNet/Mesh.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/ThirdParty/LibTessDotNet/Mesh.cs
@@ -33,8 +33,6 @@
 
 // Seanba edit: Put LibTessDotNet in unique namespace so avoid name collisions
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 
 #if DOUBLE

--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/ThirdParty/LibTessDotNet/MeshUtils.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/ThirdParty/LibTessDotNet/MeshUtils.cs
@@ -38,7 +38,6 @@
 #endif
 
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 

--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/ThirdParty/MaxRectsBinPack.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/ThirdParty/MaxRectsBinPack.cs
@@ -9,7 +9,6 @@
 // Seanba change: Put into namespace so we don't collide with other usage of this popular utility
 
 using UnityEngine;
-using System.Collections;
 using System.Collections.Generic;
 
 namespace SuperTiled2Unity.Editor.ThirdParty

--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/ThirdParty/MultiValueDictionary.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/ThirdParty/MultiValueDictionary.cs
@@ -32,11 +32,8 @@
 // Seanba edit: Put into SuperTiled2Unity namespace to avoid name collisions
 // Seanba edit: Not using using SD.Tools.Algorithmia.UtilityClasses
 
-using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
-using System.Text;
 //using SD.Tools.Algorithmia.UtilityClasses;
 
 namespace SuperTiled2Unity.Editor.SD.Tools.Algorithmia.GeneralDataStructures

--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/SuperObject.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/SuperObject.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using UnityEngine;
-using UnityEngine.Assertions;
+﻿using UnityEngine;
 
 namespace SuperTiled2Unity
 {

--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/SuperObjectLayer.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/SuperObjectLayer.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using UnityEngine;
+﻿using UnityEngine;
 
 namespace SuperTiled2Unity
 {

--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/SuperTileLayer.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/SuperTileLayer.cs
@@ -1,6 +1,4 @@
-﻿using UnityEngine;
-
-namespace SuperTiled2Unity
+﻿namespace SuperTiled2Unity
 {
     public class SuperTileLayer : SuperLayer
     {

--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/TileObjectAnimator.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/TileObjectAnimator.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using UnityEngine;
+﻿using UnityEngine;
 
 namespace SuperTiled2Unity
 {


### PR DESCRIPTION
I like to compile my project (outside of Unity), and keep my compilation warnings to a minimum.

Hopefully I've respected the line-endings and kept the BOM identifier in each file.