### PR TITLE
Prefab Replacement with no GameObject

### DIFF
--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Importers/TmxAssetImporter.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Importers/TmxAssetImporter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Xml.Linq;
@@ -399,6 +399,12 @@ namespace SuperTiled2Unity.Editor
                     string name = so.gameObject.name;
                     DestroyImmediate(so.gameObject);
                     instance.name = name;
+                }
+                else
+                {
+                    // Ignore game object as per Prefab Replacements (Object Type present but no game object to replace with)
+                    Debug.LogWarningFormat("Prefab Replacements-> Ignoring GameObject: {0} in map {1} (Object Type present but no game object to replace with)", so.gameObject.name, m_MapComponent.gameObject.name);
+                    DestroyImmediate(so.gameObject);                    
                 }
             }
         }

--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Settings/ST2USettingsProvider.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Settings/ST2USettingsProvider.cs
@@ -209,7 +209,7 @@ namespace SuperTiled2Unity.Editor
                     }
                 }
 
-                EditorGUILayout.HelpBox("When the Tiled import scripts come across a Tiled Object of one of these given types it will be replaced, automatically, with the associated prefab.", MessageType.None);
+                EditorGUILayout.HelpBox("When the Tiled import scripts come across a Tiled Object of one of these given types it will be replaced, automatically, with the associated prefab.\nNote: If no game object is specified, the Tiled Object won't be imported (ignored)", MessageType.None);
             }
         }
 


### PR DESCRIPTION
Prefab Replacement setting allows you to set a Tiled Object Type name while leaving the GameObject part empty, then SuperTiled2Unity ignores it.

What I have done here allows you to set a Tiled Object Type and by not selecting a GameObject to replace it with, you can ignore the whole Tiled Object Type. This is particularly useful when you want to have 2 different behaviours on two different Unity Projects but with the same Tiled Project.

I know this could be achieved with CustomImporters but I also feel like this is the "right" behaviour when you are allowed to set a Tiled Object Type and leave the GameObject section null