### PR TITLE
Prefab replacements with no game object

### DIFF
--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Importers/TmxAssetImporter.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Importers/TmxAssetImporter.cs
@@ -377,28 +377,38 @@ namespace SuperTiled2Unity.Editor
             foreach (var so in supers)
             {
                 var prefab = SuperImportContext.Settings.GetPrefabReplacement(so.m_Type);
+
                 if (prefab != null)
                 {
-                    // Replace the super object with the instantiated prefab
-                    var instance = (GameObject)PrefabUtility.InstantiatePrefab(prefab);
-                    instance.transform.SetParent(so.transform.parent);
-                    instance.transform.position = so.transform.position + prefab.transform.localPosition;
-                    instance.transform.rotation = so.transform.rotation;
-
-                    // Apply custom properties as messages to the instanced prefab
-                    var props = so.GetComponent<SuperCustomProperties>();
-                    if (props != null)
+                    if (prefab.m_Prefab != null)
                     {
-                        foreach (var p in props.m_Properties)
-                        {
-                            instance.gameObject.BroadcastProperty(p);
-                        }
-                    }
+                        // Replace the super object with the instantiated prefab
+                        var instance = (GameObject)PrefabUtility.InstantiatePrefab(prefab.m_Prefab);
+                        instance.transform.SetParent(so.transform.parent);
+                        instance.transform.position = so.transform.position + prefab.m_Prefab.transform.localPosition;
+                        instance.transform.rotation = so.transform.rotation;
 
-                    // Keep the name from Tiled.
-                    string name = so.gameObject.name;
-                    DestroyImmediate(so.gameObject);
-                    instance.name = name;
+                        // Apply custom properties as messages to the instanced prefab
+                        var props = so.GetComponent<SuperCustomProperties>();
+                        if (props != null)
+                        {
+                            foreach (var p in props.m_Properties)
+                            {
+                                instance.gameObject.BroadcastProperty(p);
+                            }
+                        }
+
+                        // Keep the name from Tiled.
+                        string name = so.gameObject.name;
+                        DestroyImmediate(so.gameObject);
+                        instance.name = name;
+                    }
+                    else if (prefab.m_TypeName == so.m_Type)
+                    {
+                        // Ignore game object as per Prefab Replacements (Object Type present but no game object to replace with)
+                        Debug.LogWarningFormat("Prefab Replacements-> Ignoring GameObject: {0} in map {1} (Object Type: {2} present but no game object to replace with)", so.gameObject.name, m_MapComponent.gameObject.name, so.m_Type);
+                        DestroyImmediate(so.gameObject);
+                    }
                 }
             }
         }

--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Settings/ST2USettings.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Settings/ST2USettings.cs
@@ -176,12 +176,12 @@ namespace SuperTiled2Unity.Editor
             }
         }
 
-        public GameObject GetPrefabReplacement(string type)
+        public TypePrefabReplacement GetPrefabReplacement(string type)
         {
             var replacement = PrefabReplacements.FirstOrDefault(r => r.m_TypeName == type);
             if (replacement != null)
             {
-                return replacement.m_Prefab;
+                return replacement;
             }
 
             return null;

--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Settings/ST2USettingsProvider.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Settings/ST2USettingsProvider.cs
@@ -209,7 +209,7 @@ namespace SuperTiled2Unity.Editor
                     }
                 }
 
-                EditorGUILayout.HelpBox("When the Tiled import scripts come across a Tiled Object of one of these given types it will be replaced, automatically, with the associated prefab.", MessageType.None);
+                EditorGUILayout.HelpBox("When the Tiled import scripts come across a Tiled Object of one of these given types it will be replaced, automatically, with the associated prefab.\nNote: If no game object is specified, the Tiled Object won't be imported (ignored)", MessageType.None);
             }
         }
 


### PR DESCRIPTION
Prefab Replacement setting allows you to set a Tiled Object Type name while leaving the GameObject part empty, then SuperTiled2Unity ignores it.

What I have done here allows you to set a Tiled Object Type and by not selecting a GameObject to replace it with, you can ignore the whole Tiled Object Type. This is particularly useful when you want to have 2 different behaviors on two different Unity Projects but with the same Tiled Project.

I know this could be achieved with CustomImporters but I also feel like this is the "right" behavior when you are allowed to set a Tiled Object Type and leave the GameObject section null

Related to https://github.com/Seanba/SuperTiled2Unity/issues/132