### PR TITLE
Fix for "System.Reflection.ReflectionTypeLoadException"

### DIFF
--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Extensions/AppDomainExtensions.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Extensions/AppDomainExtensions.cs
@@ -5,19 +5,43 @@ namespace SuperTiled2Unity.Editor
 {
     public static class AppDomainExtensions
     {
+        public static ICollection<Type> GetMatchingTypesInAssembly(this Assembly assembly, Predicate<Type> predicate)
+        {
+            ICollection<Type> types = new List<Type>();
+            try
+            {
+                types = assembly.GetTypes().Where(i => i != null && predicate(i) && i.Assembly == assembly).ToList();
+            }
+            catch (ReflectionTypeLoadException ex)
+            {
+                foreach (Type theType in ex.Types)
+                {
+                    try
+                    {
+                        if (theType != null && predicate(theType) && theType.Assembly == assembly)
+                        {
+                            types.Add(theType);
+                        }
+                    }
+                    catch (ReflectionTypeLoadException e)
+                    {
+                    }
+                }
+            }
+            return types;
+        }
+
         public static IEnumerable<Type> GetAllDerivedTypes<T>(this AppDomain appDomain)
         {
             var baseType = typeof(T);
             var derivedTypes = new List<Type>();
 
+            //  Fix adapted from: https://stackoverflow.com/questions/7889228/how-to-prevent-reflectiontypeloadexception-when-calling-assembly-gettypes/12906892
             foreach (var assembly in appDomain.GetAssemblies())
             {
-                foreach (var type in assembly.GetTypes())
+                if (assembly != null)
                 {
-                    if (type.IsSubclassOf(baseType))
-                    {
-                        derivedTypes.Add(type);
-                    }
+                    derivedTypes.AddRange(assembly.GetMatchingTypesInAssembly(t => t.IsSubclassOf(baseType)));
                 }
             }
 


### PR DESCRIPTION
Fixed an issue trying to find custom importers when loading assemblies

```
Unknown error of type System.Reflection.ReflectionTypeLoadException: Exception of type 'System.Reflection.ReflectionTypeLoadException' was thrown.
Stack Trace:
  at (wrapper managed-to-native) System.Reflection.Assembly.GetTypes(System.Reflection.Assembly,bool)
  at System.Reflection.Assembly.GetTypes () [0x00000] in <437ba245d8404784b9fbab9b439ac908>:0 
  at SuperTiled2Unity.Editor.AppDomainExtensions.GetAllDerivedTypes[T] (System.AppDomain appDomain) [0x00024] in C:\Users\Jak\Documents\Personal\Crawler\Assets\SuperTiled2Unity\Scripts\Editor\Extensions\AppDomainExtensions.cs:45 
  at SuperTiled2Unity.Editor.AutoCustomTmxImporterAttribute.GetOrderedAutoImportersTypes () [0x00001] in C:\Users\Jak\Documents\Personal\Crawler\Assets\SuperTiled2Unity\Scripts\Editor\Attributes\AutoCustomTmxImporterAttribute.cs:26 
  at SuperTiled2Unity.Editor.TmxAssetImporter.ApplyAutoImporters () [0x00002] in C:\Users\Jak\Documents\Personal\Crawler\Assets\SuperTiled2Unity\Scripts\Editor\Importers\TmxAssetImporter.cs:430 
  at SuperTiled2Unity.Editor.TmxAssetImporter.DoCustomImporting () [0x00008] in C:\Users\Jak\Documents\Personal\Crawler\Assets\SuperTiled2Unity\Scripts\Editor\Importers\TmxAssetImporter.cs:409 
  at SuperTiled2Unity.Editor.TmxAssetImporter.InternalOnImportAsset () [0x0004e] in C:\Users\Jak\Documents\Personal\Crawler\Assets\SuperTiled2Unity\Scripts\Editor\Importers\TmxAssetImporter.cs:55 
  at SuperTiled2Unity.Editor.SuperImporter.OnImportAsset (UnityEditor.Experimental.AssetImporters.AssetImportContext ctx) [0x00065] in C:\Users\Jak\Documents\Personal\Crawler\Assets\SuperTiled2Unity\Scripts\Editor\Importers\SuperImporter.cs:72 
```