### PR TITLE
Add unity:prefabKeepObject/Collider

### DIFF
--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/CollisionObject.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/CollisionObject.cs
@@ -52,6 +52,14 @@ namespace SuperTiled2Unity
             m_Points[3] = new Vector2(m_Size.x, 0);
         }
 
+        public void MakePoint()
+        {
+            m_CollisionShapeType = CollisionShapeType.Point;
+            m_IsClosed = false;
+            m_Points = new Vector2[1];
+            m_Points[0] = m_Position;
+        }
+
         public void MakePointsFromEllipse(int numEdges)
         {
             m_CollisionShapeType = CollisionShapeType.Ellipse;

--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/CollisionShapeType.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/CollisionShapeType.cs
@@ -6,5 +6,6 @@
         Ellipse,
         Polygon,
         Polyline,
+        Point,
     }
 }

--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/AtlasBuilder.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/AtlasBuilder.cs
@@ -21,6 +21,7 @@ namespace SuperTiled2Unity.Editor
 
             public Texture2D AtlasTexture;
             public Rect AtlasRectangle;
+            public Vector2 Pivot = Vector2.zero;
 
             public Texture2D PreferredTexture2D
             {
@@ -62,9 +63,9 @@ namespace SuperTiled2Unity.Editor
             m_TilesetScript = tilesetScript;
         }
 
-        public void AddTile(int index, Texture2D texSource, Rect rcSource)
+        public void AddTile(int index, Texture2D texSource, Rect rcSource, Vector2 pivot)
         {
-            var atlasTile = new AtlasTile() { Index = index, SourceTexture = texSource, SourceRectangle = rcSource };
+            var atlasTile = new AtlasTile() { Index = index, SourceTexture = texSource, SourceRectangle = rcSource, Pivot = pivot };
             m_AtlasTiles.Add(atlasTile);
         }
 
@@ -217,8 +218,8 @@ namespace SuperTiled2Unity.Editor
                 string spriteName = string.Format("Sprite_{0}_{1}", m_TilesetScript.name, t.Index + 1);
                 string tileName = string.Format("Tile_{0}_{1}", m_TilesetScript.name, t.Index + 1);
 
-                // Create the sprite with the anchor at (0, 0)
-                var sprite = Sprite.Create(t.PreferredTexture2D, t.PreferredRectangle, Vector2.zero, m_TiledAssetImporter.SuperImportContext.Settings.PixelsPerUnit);
+                // Create the sprite according to its pivot
+                var sprite = Sprite.Create(t.PreferredTexture2D, t.PreferredRectangle, t.Pivot, m_TiledAssetImporter.SuperImportContext.Settings.PixelsPerUnit);
 
                 sprite.name = spriteName;
                 sprite.hideFlags = HideFlags.HideInHierarchy;
@@ -232,8 +233,9 @@ namespace SuperTiled2Unity.Editor
                 tile.m_Sprite = sprite;
                 tile.m_Width = t.SourceRectangle.width;
                 tile.m_Height = t.SourceRectangle.height;
-                tile.m_TileOffsetX = m_TilesetScript.m_TileOffset.x;
-                tile.m_TileOffsetY = m_TilesetScript.m_TileOffset.y;
+                // NOTE: We adjust the tile offset by the pivot amount to we still render in the correct position.
+                tile.m_TileOffsetX = m_TilesetScript.m_TileOffset.x + (t.Pivot.x * tile.m_Width);
+                tile.m_TileOffsetY = m_TilesetScript.m_TileOffset.y - (t.Pivot.y * tile.m_Height);
                 tile.m_ObjectAlignment = m_TilesetScript.m_ObjectAlignment;
 
                 m_TilesetScript.m_Tiles.Add(tile);

--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Extensions/CollisionObjectExtensions.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Extensions/CollisionObjectExtensions.cs
@@ -25,6 +25,10 @@ namespace SuperTiled2Unity.Editor
             {
                 AddBoxCollider(go, collision, tile, importContext);
             }
+            else if (collision.CollisionShapeType == CollisionShapeType.Point)
+            {
+                AddPointCollider(go, collision, importContext);
+            }
 
             // Additional settings on the collider that was just added
             var addedCollider = go.GetComponent<Collider2D>();
@@ -89,6 +93,17 @@ namespace SuperTiled2Unity.Editor
             box.offset = importContext.MakePointPPU(collision.m_Size.x, -collision.m_Size.y) * 0.5f;
             box.size = importContext.MakeSize(collision.m_Size);
 
+            var xpos = importContext.MakeScalar(collision.m_Position.x);
+            var ypos = importContext.MakeScalar(collision.m_Position.y);
+
+            go.transform.localPosition = new Vector3(xpos, ypos);
+            go.transform.localEulerAngles = new Vector3(0, 0, importContext.MakeRotation(collision.m_Rotation));
+
+            go.AddComponent<SuperColliderComponent>();
+        }
+
+        private static void AddPointCollider(GameObject go, CollisionObject collision, SuperImportContext importContext)
+        {
             var xpos = importContext.MakeScalar(collision.m_Position.x);
             var ypos = importContext.MakeScalar(collision.m_Position.y);
 

--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Importers/TiledAssetImporter.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Importers/TiledAssetImporter.cs
@@ -110,7 +110,7 @@ namespace SuperTiled2Unity.Editor
             }
         }
 
-        public void ApplyDefaultSettings()
+        virtual public void ApplyDefaultSettings()
         {
             var settings = ST2USettings.GetOrCreateST2USettings();
             m_PixelsPerUnit = settings.PixelsPerUnit;
@@ -174,7 +174,7 @@ namespace SuperTiled2Unity.Editor
             }
         }
 
-        private void WrapImportContext(AssetImportContext ctx)
+        virtual protected void WrapImportContext(AssetImportContext ctx)
         {
             var settings = ST2USettings.GetOrCreateST2USettings();
             settings.RefreshCustomObjectTypes();

--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Importers/TmxAssetImporter.TileLayer.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Importers/TmxAssetImporter.TileLayer.cs
@@ -91,6 +91,7 @@ namespace SuperTiled2Unity.Editor
                     // Each chunk is a separate game object on the super layer
                     GameObject goChunk = new GameObject(string.Format("Chunk ({0},{1})", chunk.X, chunk.Y));
                     goLayer.AddChildWithUniqueName(goChunk);
+                    goChunk.layer = goLayer.layer;
 
                     ProcessLayerDataChunk(goChunk, chunk);
                 }
@@ -156,7 +157,7 @@ namespace SuperTiled2Unity.Editor
             AssignTilemapSorting(renderer);
 
 #if UNITY_2018_3_OR_NEWER
-            if (m_SortingMode == SortingMode.CustomSortAxis)
+            if (m_SortingMode == SortingMode.CustomSortAxis || m_SortingMode == SortingMode.CustomSortAxisManual)
             {
                 renderer.mode = TilemapRenderer.Mode.Individual;
             }

--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Importers/TmxAssetImporter.TileLayer.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Importers/TmxAssetImporter.TileLayer.cs
@@ -149,9 +149,7 @@ namespace SuperTiled2Unity.Editor
             var renderer = go.AddComponent<TilemapRenderer>();
             renderer.sortOrder = MapRenderConverter.Tiled2Unity(m_MapComponent.m_RenderOrder);
 
-            // This is a hack so that Unity does not falsely detect prefab instance differences.
-            // See the SuperMap.Start method where this is put to Auto to make up for this.
-            renderer.detectChunkCullingBounds = TilemapRenderer.DetectChunkCullingBounds.Manual;
+            renderer.detectChunkCullingBounds = TilemapRenderer.DetectChunkCullingBounds.Auto;
 
             AssignMaterial(renderer, m_CurrentTileLayer.m_TiledName);
             AssignTilemapSorting(renderer);

--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Importers/TmxAssetImporter.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Importers/TmxAssetImporter.cs
@@ -435,6 +435,26 @@ namespace SuperTiled2Unity.Editor
                         }
                     }
 
+                    if (so.gameObject.GetSuperPropertyValueBool(StringConstants.Unity_PrefabKeepObject, false))
+                    {
+                        var superObjectCopy = instance.gameObject.AddComponent<SuperObject>();
+                        EditorUtility.CopySerialized(so, superObjectCopy);
+                    }
+
+                    if (so.gameObject.GetSuperPropertyValueBool(StringConstants.Unity_PrefabKeepCollider, false))
+                    {
+                        var origCollider = so.GetComponent<Collider2D>();
+                        if (origCollider != null) {
+                            var colliderCopy = instance.gameObject.AddComponent(origCollider.GetType());
+                            EditorUtility.CopySerialized(origCollider, colliderCopy);
+                        }
+                        var origSuper = so.GetComponent<SuperColliderComponent>();
+                        if (origSuper != null) {
+                            var superColliderCopy = instance.gameObject.AddComponent<SuperColliderComponent>();
+                            EditorUtility.CopySerialized(origSuper, superColliderCopy);
+                        }
+                    }
+
                     // Keep the name from Tiled.
                     string name = so.gameObject.name;
                     DestroyImmediate(so.gameObject);

--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Importers/TmxAssetImporter.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Importers/TmxAssetImporter.cs
@@ -44,6 +44,25 @@ namespace SuperTiled2Unity.Editor
         [SerializeField]
         private List<SuperTileset> m_InternalTilesets;
 
+        override public void ApplyDefaultSettings()
+        {
+            base.ApplyDefaultSettings();
+            var settings = ST2USettings.GetOrCreateST2USettings();
+            m_SortingMode = settings.SortingMode;
+            EditorUtility.SetDirty(this);
+        }
+
+        override protected void WrapImportContext(UnityEditor.AssetImporters.AssetImportContext ctx) {
+            base.WrapImportContext(ctx);
+
+            if ((int)m_SortingMode == 0)
+            {
+                m_SortingMode = SuperImportContext.Settings.SortingMode;
+            } else if ((int)m_SortingMode == 1) {
+                m_SortingMode = SortingMode.CustomSortAxis;
+            }
+        }
+
         protected override void InternalOnImportAsset()
         {
             base.InternalOnImportAsset();

--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Importers/TmxAssetImporter.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Importers/TmxAssetImporter.cs
@@ -31,7 +31,7 @@ namespace SuperTiled2Unity.Editor
         public bool TilesAsObjects { get { return m_TilesAsObjects; } }
 
         [SerializeField]
-        private SortingMode m_SortingMode = SortingMode.Stacked;
+        private SortingMode m_SortingMode;
         public SortingMode SortingMode { get { return m_SortingMode; } }
 
         [SerializeField]

--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Importers/TmxAssetImporter.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Importers/TmxAssetImporter.cs
@@ -433,6 +433,10 @@ namespace SuperTiled2Unity.Editor
                         {
                             instance.gameObject.BroadcastProperty(p);
                         }
+                        // Unconditionally make a copy of all custom properties onto the root of the instance
+                        // in case the propeties can't broadcast correctly
+                        var superPropsCopy = instance.gameObject.AddComponent<SuperCustomProperties>();
+                        EditorUtility.CopySerialized(props, superPropsCopy);
                     }
 
                     if (so.gameObject.GetSuperPropertyValueBool(StringConstants.Unity_PrefabKeepObject, false))

--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Importers/TmxAssetImporterEditor.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Importers/TmxAssetImporterEditor.cs
@@ -51,7 +51,7 @@ namespace SuperTiled2Unity.Editor
 
             m_SortingMode.intValue = (int)(SortingMode)EditorGUILayout.EnumPopup(m_SortingModeContent, (SortingMode)m_SortingMode.intValue);
 
-            if (m_SortingMode.intValue == (int)SortingMode.CustomSortAxis)
+            if (m_SortingMode.intValue == (int)SortingMode.CustomSortAxis || m_SortingMode.intValue == (int)SortingMode.CustomSortAxisManual)
             {
                 EditorGUILayout.HelpBox("Tip: Custom Sort Axis may require you to set a Transparency Sort Axis for cameras in your project Graphics settings.", MessageType.Info);
             }

--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Loaders/SuperObjectLayerLoader.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Loaders/SuperObjectLayerLoader.cs
@@ -102,15 +102,7 @@ namespace SuperTiled2Unity.Editor
             comp.m_Template = xObject.GetAttributeAs("template", "");
 
             // Assign the name of our game object
-            if (comp.m_TileId != 0)
-            {
-                // The tile object name is decorated. A descendent will have the "real" object name.
-                goObject.name = string.Format("{0} (TRS)", comp.m_TiledName);
-            }
-            else
-            {
-                goObject.name = comp.m_TiledName;
-            }
+            goObject.name = comp.m_TiledName;
 
             // Position the game object
             var localPosition = new Vector2(comp.m_X, comp.m_Y);
@@ -256,7 +248,7 @@ namespace SuperTiled2Unity.Editor
             var fromCenter = -translateCenter;
 
             // Add another child, putting our coordinates back into the proper place
-            var goTile = new GameObject(superObject.m_TiledName);
+            var goTile = new GameObject($"{superObject.m_TiledName} (Tile)");
             goCF.AddChildWithUniqueName(goTile);
             goTile.transform.localPosition = fromCenter;
             goTile.transform.localRotation = Quaternion.Euler(0, 0, 0);

--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Loaders/SuperObjectLayerLoader.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Loaders/SuperObjectLayerLoader.cs
@@ -268,6 +268,7 @@ namespace SuperTiled2Unity.Editor
                 var renderer = goTile.AddComponent<SpriteRenderer>();
                 renderer.sprite = tile.m_Sprite;
                 renderer.color = superObject.CalculateColor();
+                renderer.spriteSortPoint = SpriteSortPoint.Pivot;
                 Importer.AssignMaterial(renderer, m_ObjectLayer.m_TiledName);
                 Importer.AssignSpriteSorting(renderer);
 

--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Loaders/TilesetLoader.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Loaders/TilesetLoader.cs
@@ -311,8 +311,8 @@ namespace SuperTiled2Unity.Editor
                     collision.m_ObjectId = xObject.GetAttributeAs("id", 0);
                     collision.m_ObjectName = xObject.GetAttributeAs("name", string.Format("Object_{0}", collision.m_ObjectId));
                     collision.m_ObjectType = xObject.GetAttributeAs("type", "");
-                    collision.m_Position.x = xObject.GetAttributeAs("x", 0.0f);
-                    collision.m_Position.y = xObject.GetAttributeAs("y", 0.0f);
+                    collision.m_Position.x = xObject.GetAttributeAs("x", 0.0f) - tile.m_TileOffsetX;
+                    collision.m_Position.y = xObject.GetAttributeAs("y", 0.0f) - tile.m_TileOffsetY;
                     collision.m_Size.x = xObject.GetAttributeAs("width", 0.0f);
                     collision.m_Size.y = xObject.GetAttributeAs("height", 0.0f);
                     collision.m_Rotation = xObject.GetAttributeAs("rotation", 0.0f);

--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Settings/ST2USettings.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Settings/ST2USettings.cs
@@ -32,6 +32,10 @@ namespace SuperTiled2Unity.Editor
         public int AnimationFramerate {  get { return m_AnimationFramerate; } }
 
         [SerializeField]
+        private SortingMode m_SortingMode = SortingMode.Stacked;
+        public SortingMode SortingMode {  get { return m_SortingMode; } }
+
+        [SerializeField]
         private Material m_DefaultMaterial = null;
         public Material DefaultMaterial { get { return m_DefaultMaterial; } }
 

--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Settings/ST2USettingsProvider.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Settings/ST2USettingsProvider.cs
@@ -29,6 +29,7 @@ namespace SuperTiled2Unity.Editor
             public static readonly GUIContent m_PixelsPerUnitContent = new GUIContent("Default Pixels Per Unit", "How many pixels in the sprite correspond to one unit in the world. (Default Setting)");
             public static readonly GUIContent m_EdgesPerEllipseContent = new GUIContent("Default Edges Per Ellipse", "How many edges to use when appromixating ellipse/circle colliders. (Default Setting)");
             public static readonly GUIContent m_AnimationFramerateContent = new GUIContent("Animation Framerate", "How many frames per second for tile animations.");
+            public static readonly GUIContent m_SortingModeContent = new GUIContent("Default Sorting Mode", "Set to the default sorting mode you want to be used in newly imported .tmx files imported by SuperTiled2Unity.");
             public static readonly GUIContent m_DefaultMaterialContent = new GUIContent("Default Material", "Set to the material you want to use for sprites and tiles imported by SuperTiled2Unity. Leave empy to use built-in sprite material.");
             public static readonly GUIContent m_MaterialMatchingsContent = new GUIContent("Material Matchings", "Match these materials by Tiled Layer names.");
             public static readonly GUIContent m_ObjectTypesXmlContent = new GUIContent("Object Types Xml", "Set to an Object Types Xml file exported from Tiled Object Type Editor.");
@@ -123,6 +124,7 @@ namespace SuperTiled2Unity.Editor
         {
             var ppuProperty = m_S2TUSettingsObject.FindProperty("m_PixelsPerUnit");
             var edgesProperty = m_S2TUSettingsObject.FindProperty("m_EdgesPerEllipse");
+            var sortingModeProperty = m_S2TUSettingsObject.FindProperty("m_SortingMode");
             var materialProperty = m_S2TUSettingsObject.FindProperty("m_DefaultMaterial");
             var animationPrpoerty = m_S2TUSettingsObject.FindProperty("m_AnimationFramerate");
 
@@ -143,6 +145,9 @@ namespace SuperTiled2Unity.Editor
             {
                 edgesProperty.intValue = Mathf.Clamp(edgesProperty.intValue, 6, 256);
             }
+
+            // Default Sorting Mode
+            EditorGUILayout.PropertyField(sortingModeProperty, SettingsContent.m_SortingModeContent);
 
             // Default Material
             EditorGUILayout.PropertyField(materialProperty, SettingsContent.m_DefaultMaterialContent);

--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/SortingMode.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/SortingMode.cs
@@ -2,7 +2,8 @@
 {
     public enum SortingMode
     {
-        Stacked = 0,
+        Stacked = 10,
         CustomSortAxis,
+        CustomSortAxisManual,
     }
 }

--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/StringConstants.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/StringConstants.cs
@@ -6,6 +6,9 @@
         public const string Unity_Ignore = Unity_Prefix + "ignore";
         public const string Unity_IsTrigger = Unity_Prefix + "IsTrigger";
         public const string Unity_Layer = Unity_Prefix + "layer";
+        public const string Unity_Pivot = Unity_Prefix + "pivot";
+        public const string Unity_PrefabKeepObject = Unity_Prefix + "prefabKeepObject";
+        public const string Unity_PrefabKeepCollider = Unity_Prefix + "prefabKeepCollider";
         public const string Unity_SortingLayer = Unity_Prefix + "SortingLayer";
         public const string Unity_SortingLayerName = Unity_Prefix + "SortingLayerName";
         public const string Unity_SortingOrder = Unity_Prefix + "SortingOrder";

--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/SuperMap.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/SuperMap.cs
@@ -47,16 +47,6 @@ namespace SuperTiled2Unity
         [ReadOnly]
         public int m_NextObjectId;
 
-        private void Start()
-        {
-            // This is a hack so that Unity does not falsely report prefab instance differences from our importer map
-            // Look for where renderer.detectChunkCullingBounds is set to Manual in the importer code which is the other part of this hack
-            foreach (var renderer in GetComponentsInChildren<TilemapRenderer>())
-            {
-                renderer.detectChunkCullingBounds = TilemapRenderer.DetectChunkCullingBounds.Auto;
-            }
-        }
-
         public Vector3Int TiledIndexToGridCell(int index, int offset_x, int offset_y, int stride)
         {
             int x = index % stride;

--- a/docs/manual/custom-properties-importing.rst
+++ b/docs/manual/custom-properties-importing.rst
@@ -19,6 +19,8 @@ These custom properties always have a :code:`unity:` prefix so that they do not 
       * **Collision**: The colliders are not imported for the layer."
    ":code:`unity:IsTrigger`", ":code:`bool`", "Layers, Tileset, Tile, Collider, Collider Group", "Controls the :code:`isTrigger` setting of the :code:`Collider2D` object generated in the prefab. Add as a layer custom property to override all colliders for a given layer."
    ":code:`unity:layer`", ":code:`string`", "Layers, Tileset, Tile, Collider, Collider Group", "Controls which Unity phyisics layer our generated colliders are assigned. The layer name must exist in your project's Tag Manager."
+   ":code:`unity:prefabKeepCollider`", ":code:`bool`", "Collider", "If set on an object using prefab replacements, copies the Collider onto the replacement prefab."
+   ":code:`unity:prefabKeepObject`", ":code:`bool`", Collider", "If set on an object using prefab replacements, copies the SuperObject onto the replacement prefab."
    ":code:`unity:SortingLayer`", ":code:`string`", "Layers, Tile Objects", "Controls which sorting layer is assigned to the Unity :code:`Renderer` component created for your tilemaps and sprites. The sorting layer name must exist in your project's Tag Manager."
    ":code:`unity:SortingOrder`", ":code:`int`", "Layers, Tile Objects", "Controls which sorting order is applied to the Unity :code:`Renderer` component created for your tilemaps and sprites."
    ":code:`unity:Tag`", ":code:`string`", "Layers, Objects", "Controls which tag is applied to the :code:`GameObject` created for your layers and objects. The tag must exist in your project's Tag Manager."


### PR DESCRIPTION
Using prefab replacement nukes the SuperObject, SuperCollider, and Collider
metadata imported from Unity, and while custom properties are broadcast
onto your prefab, there is no way to retain the object geometry or tile
metadata.

Add two new unity attributes, unity:prefabKeepObject and
unity:prefabKeepCollider, that on import, checks if set on the object,
and if so, creates a copy of the SuperObject or the SuperColliderComponent
and Collider2D and copies them onto the root node in the prefab.