### PR TITLE
Support private and protected Custom Properties

### DIFF
--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Extensions/GameObjectExtensions.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Extensions/GameObjectExtensions.cs
@@ -173,7 +173,7 @@ namespace SuperTiled2Unity.Editor
                     continue;
                 }
 
-                // Finally, look for public fields
+                // Finally, look for fields
                 var csfield = FindFieldBySignature(comp, property.m_Name, objValue.GetType());
                 if (csfield != null)
                 {
@@ -185,7 +185,7 @@ namespace SuperTiled2Unity.Editor
 
         private static MethodInfo FindMethodBySignature(MonoBehaviour component, string name, Type paramType)
         {
-            return component.GetType().GetMethods(BindingFlags.Instance | BindingFlags.Public).Where(info =>
+            return component.GetType().GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic).Where(info =>
             {
                 // Name must match
                 if (info.Name != name)
@@ -218,8 +218,7 @@ namespace SuperTiled2Unity.Editor
 
         private static PropertyInfo FindPropertyBySignature(MonoBehaviour component, string name, Type valueType)
         {
-            // Property must be public and instanced and writable
-            return component.GetType().GetProperties(BindingFlags.Instance | BindingFlags.Public).Where(
+            return component.GetType().GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic).Where(
                 info =>
                 info.CanWrite &&
                 info.Name == name &&
@@ -229,7 +228,7 @@ namespace SuperTiled2Unity.Editor
 
         private static FieldInfo FindFieldBySignature(MonoBehaviour component, string name, Type valueType)
         {
-            return component.GetType().GetFields(BindingFlags.Instance | BindingFlags.Public).Where(
+            return component.GetType().GetFields(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic).Where(
                 info =>
                 !info.IsInitOnly &&
                 info.Name == name &&

--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Extensions/GameObjectExtensions.cs.orig
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Extensions/GameObjectExtensions.cs.orig
@@ -1,0 +1,48 @@
+﻿using UnityEngine;
+
+namespace SuperTiled2Unity
+{
+    public static class GameObjectExtensions
+    {
+        // Like GetComponentInParent but doesn't check current object
+        public static T GetComponentInAncestor<T>(this MonoBehaviour mono) where T : MonoBehaviour
+        {
+            return GetComponentInAncestor<T>(mono.gameObject);
+        }
+
+        // Like GetComponentInParent but doesn't check current object
+        public static T GetComponentInAncestor<T>(this GameObject go) where T : MonoBehaviour
+        {
+            if (go == null)
+            {
+                return null;
+            }
+
+            var parent = go.transform.parent;
+            if (parent == null)
+            {
+                return null;
+            }
+
+            return parent.GetComponentInParent<T>();
+        }
+
+        public static bool TryGetCustomPropertySafe(this GameObject go, string name, out CustomProperty property)
+        {
+            property = null;
+
+            if (go == null)
+            {
+                return false;
+            }
+
+            var customProperties = go.GetComponent<SuperCustomProperties>();
+            if (customProperties == null)
+            {
+                return false;
+            }
+
+            return customProperties.TryGetCustomProperty(name, out property);
+        }
+    }
+}


### PR DESCRIPTION
It is common and good practice to make properties and fields private or protected, so that the code flow becomes more obvious (fewer ways to change the state of a class instance) and less error prone.

For that reason codebases that protected most properties from other classes and utilize SuperTiled2Unity cannot use Custom Properties unless applying this patch.

On the patch correctness:
The reasoning to only write to public fields might have been to be consistent with the access modifier.
The counterargument to that would be that Unity well supports serialization and deserialization of private and protected fields, by using the `[SerializeField]` attribute. And the tiled 2 unity import process resembles deserialization.

If it is deemed important to distinguish public and non-public property Custom Properties, then one might add another checkbox in the Import user interface (similar to the `Tiles As Objects` checkbox).
