### PR TITLE
Massive performance boost by disabling Physics Updates during the TMX map import process

### DIFF
--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Importers/SuperImporter.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Importers/SuperImporter.cs
@@ -68,8 +68,16 @@ namespace SuperTiled2Unity.Editor
 #if UNITY_2018_3_OR_NEWER
             try
             {
+                // Disable Physics simulation during the map import process.
+                // This is necessary because each time a Collider2D is constructed, there is a full Physics2D update.
+                // This can make the map import process several hundred times slower for no reason.
+                bool physics_simulation = Physics.autoSimulation;
+                Physics.autoSimulation = false;
+
                 InternalOnImportAsset();
                 InternalOnImportAssetCompleted();
+
+                Physics.autoSimulation = physics_simulation;
             }
             catch (TiledException tiled)
             {


### PR DESCRIPTION
**TLDR:** 10 minute vs 15 second performance difference when Physics updates are disabled while importing a TMX file with 2000+ colliders.

We we have been facing devastating import times of more than 10(!) minutes per TMX map file.

This time is spent not only when updating a map but also when changing a TSX file that is used by the map.

Since TSX files can be used by several maps, it can mean that there is more than half an hour to wait for this process to finish, which is obviously inacceptable, especially considering that the expected import time is something around a second.

Trial and error has shown that the importing time is proportional to the number of Colliders placed in the map.
The map that spends 10+ minutes on import has more than 2000 (perfect circle) Ellipse colliders.
Changing the "Tiles as Objects" setting and the number of "Edges Per Ellipse" in the TMX import settings does not affect the performance at all.

We know from Unity Physics that each time a Static Collider is created or moved, the entire Physics simulation state is recomputed - and all colliders imported by Tiled2Unity are Static colliders (because they aren't part of any dynamic or kinematic RigidBody).

Just disabling the Physics simulation entirely during the Asset import fixes the performance issue for us entirely and reduces the import time from 10min+ to 15 seconds!

**Correctness of the patch**:

We know (or can reasonably put that restriction to asset importers) that the asset importing process shall not depend on the Physics simulation state, so temporarily disabling the Physics simulation during the map import should not affect the resulting prefabs.

An alternative idea to addressing this issue might be to add a Dynamic or Kinematic Rigidbody and then remove that later on. But this will most likely be less performant than disabling the Physics simulation entirely.

What seems a bit ugly about this patch:
- If some `SuperImporter` code (e.g. a CustomTmxImporter) would modify `Physics.autoSimulation`, the value would be reset by the last line added in this diff. This is not an issue if we can assume that developers are reasonable enough not to write such code.
- Modifying Physics settings at all during Prefab construction time seems like going out of place of responsibility, since the asset importing code should be independent of the Physics. Evidently it already is heavily dependent on it however.

So if you have a better idea, feel free to ignore this, but we have to patch this locally since we can't use the program while the issue is present.

Avoiding to create that many Colliders is not an option for us currently, since all of these Colliders are meant to be clickable objects, smaller than one tile. Even if authors can avoid creating that many Colliders, it is still a lot of lost performance during map import time for each individual Collider that exists and causes a recomputation of the entire physics simulation state (so even with < 100 colliders it seems worth to patch).