### PR TITLE
SetDirty when changing ST2U settings through the editor

### DIFF
--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Settings/ST2USettingsProvider.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Settings/ST2USettingsProvider.cs
@@ -179,6 +179,7 @@ namespace SuperTiled2Unity.Editor
                     if (GUILayout.Button("Sort Alphabetically"))
                     {
                         m_ST2USettings.SortMaterialMatchings();
+                        EditorUtility.SetDirty(m_ST2USettings);
                     }
                 }
 
@@ -201,11 +202,13 @@ namespace SuperTiled2Unity.Editor
                     if (GUILayout.Button("Add From Object Types Xml"))
                     {
                         m_ST2USettings.AddObjectsToPrefabReplacements();
+                        EditorUtility.SetDirty(m_ST2USettings);
                     }
 
                     if (GUILayout.Button("Sort Alphabetically"))
                     {
                         m_ST2USettings.SortPrefabReplacements();
+                        EditorUtility.SetDirty(m_ST2USettings);
                     }
                 }
 


### PR DESCRIPTION
While editing the prefab replacements list in Unity Editor, I have noticed that I couldn't actually save the changes after clicking on alphabetic sort (unless doing further changes like reordering or changing the name of an object type).

Marking it using SetDirty fixes that.

**Reproduce:**
1. Open Project Settings, click on Super Tiled2 Unity, expand Prefab Replacements.
2. Make sure there are some prefab replacements in this list.
3. Order the prefab replacements so that the order is non-alphabetical.
4. Save assets, using Ctrl+S or File -> Save.
5. Notice that the file wasn't actually saved (for example using git revision system).
6. Apply this patch.
7. Repeat Step 1 to 4 and notice that the file was actually saved.

I don't know how many more SetDirty calls are missing (there was #172 already), but at least all GUI buttons in this file should be covered.