### PR TITLE
Add parallax x/y fields to SuperLayer

### DIFF
--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Loaders/SuperLayerLoader.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Loaders/SuperLayerLoader.cs
@@ -21,6 +21,8 @@ namespace SuperTiled2Unity.Editor
             layer.m_Visible = m_Xml.GetAttributeAs("visible", true);
             layer.m_OffsetX = m_Xml.GetAttributeAs("offsetx", 0.0f);
             layer.m_OffsetY = m_Xml.GetAttributeAs("offsety", 0.0f);
+            layer.m_ParallaxX = m_Xml.GetAttributeAs("parallaxx", 1.0f);
+            layer.m_ParallaxY = m_Xml.GetAttributeAs("parallaxy", 1.0f);
             layer.m_Opacity = m_Xml.GetAttributeAs("opacity", 1.0f);
             layer.m_TintColor = m_Xml.GetAttributeAsColor("tintcolor", Color.white);
 

--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/SuperLayer.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/SuperLayer.cs
@@ -14,6 +14,12 @@ namespace SuperTiled2Unity
         public float m_OffsetY;
 
         [ReadOnly]
+        public float m_ParallaxX;
+
+        [ReadOnly]
+        public float m_ParallaxY;
+
+        [ReadOnly]
         public float m_Opacity;
 
         [ReadOnly]


### PR DESCRIPTION
I've got my own importer that implements the rest of it, but need the
values from the xml parser on the SuperLayer for it to work.