### PR TITLE
use cache for getting all custom importer attributes

### DIFF
--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Attributes/AutoCustomTmxImporterAttribute.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Attributes/AutoCustomTmxImporterAttribute.cs
@@ -19,8 +19,11 @@ namespace SuperTiled2Unity.Editor
 
         public int Order { get; private set; }
 
+        private static List<Type> _cachedImporters;
         public static List<Type> GetOrderedAutoImportersTypes()
         {
+            if (_cachedImporters != null) return _cachedImporters;
+
             var importers = from t in AppDomain.CurrentDomain.GetAllDerivedTypes<CustomTmxImporter>()
                             where !t.IsAbstract
                             from attr in GetCustomAttributes(t, typeof(AutoCustomTmxImporterAttribute))
@@ -28,7 +31,7 @@ namespace SuperTiled2Unity.Editor
                             orderby auto.Order
                             select t;
 
-            return importers.ToList();
+            return _cachedImporters = importers.ToList();
         }
     }
 }


### PR DESCRIPTION
This is called a lot in the editor, so it creates incredible amount of
GC pressure.
Using static here is ok since the types change on domain reload and the
field is null.

This is before a fix.
<img width="1511" alt="Screenshot 2022-02-08 at 16 22 07" src="https://user-images.githubusercontent.com/154571/153048508-9eadb6c5-5874-45da-bc03-30e26f52b661.png">

After the whole part shrinks into a few ms.
