### PR TITLE
Support properties of type "object".

### DIFF
--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Extensions/GameObjectExtensions.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Extensions/GameObjectExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using UnityEngine;
@@ -128,7 +129,7 @@ namespace SuperTiled2Unity.Editor
             }
         }
 
-        public static void BroadcastProperty(this GameObject go, CustomProperty property)
+        public static void BroadcastProperty(this GameObject go, CustomProperty property, Dictionary<int, GameObject> objectsById)
         {
             object objValue = null;
 
@@ -147,6 +148,20 @@ namespace SuperTiled2Unity.Editor
             else if (property.m_Type == "int")
             {
                 objValue = property.GetValueAsInt();
+            }
+            else if (property.m_Type == "object")
+            {
+                var id = property.GetValueAsInt();
+                GameObject gameObject = null;
+                if (!objectsById.TryGetValue(id, out gameObject))
+                {
+                    Debug.LogErrorFormat("Object property refers to invalid ID {0}", id);
+                    return;
+                }
+                else
+                {
+                    objValue = gameObject;
+                }
             }
             else
             {


### PR DESCRIPTION
Tiled supports objects properties of type "object". They are handy because the object reference is visualized in the Tiled editor. However, until now, SuperTiled2Unity has been broadcasting such properties to Unity components as string properties, which is less than ideal.

With this change, Tiled properties of type "object" are interpreted as actual references to GameObjects. Tiled stores the reference as an integer ID, which I use to find the correct Unity object by matching it with the `SuperObject.m_ID` field. To make this work also with objects that have been replaced with a prefab, `DoPrefabReplacements()` temporarily remembers the original Tiled ID of each prefab replacement in a `Dictionary`. This helps to make the object property refer to the newly instantiated prefab instead of the `SuperObject` that is destroyed after prefab replacement.