### PR TITLE
Add support for "Point" collisions

### DIFF
--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/CollisionObject.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/CollisionObject.cs
@@ -52,6 +52,14 @@ namespace SuperTiled2Unity
             m_Points[3] = new Vector2(m_Size.x, 0);
         }
 
+        public void MakePoint()
+        {
+            m_CollisionShapeType = CollisionShapeType.Point;
+            m_IsClosed = false;
+            m_Points = new Vector2[1];
+            m_Points[0] = m_Position;
+        }
+
         public void MakePointsFromEllipse(int numEdges)
         {
             m_CollisionShapeType = CollisionShapeType.Ellipse;

--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/CollisionShapeType.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/CollisionShapeType.cs
@@ -6,5 +6,6 @@
         Ellipse,
         Polygon,
         Polyline,
+        Point,
     }
 }

--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Extensions/CollisionObjectExtensions.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Extensions/CollisionObjectExtensions.cs
@@ -25,6 +25,10 @@ namespace SuperTiled2Unity.Editor
             {
                 AddBoxCollider(go, collision, tile, importContext);
             }
+            else if (collision.CollisionShapeType == CollisionShapeType.Point)
+            {
+                AddPointCollider(go, collision, importContext);
+            }
 
             // Additional settings on the collider that was just added
             var addedCollider = go.GetComponent<Collider2D>();
@@ -89,6 +93,17 @@ namespace SuperTiled2Unity.Editor
             box.offset = importContext.MakePointPPU(collision.m_Size.x, -collision.m_Size.y) * 0.5f;
             box.size = importContext.MakeSize(collision.m_Size);
 
+            var xpos = importContext.MakeScalar(collision.m_Position.x);
+            var ypos = importContext.MakeScalar(collision.m_Position.y);
+
+            go.transform.localPosition = new Vector3(xpos, ypos);
+            go.transform.localEulerAngles = new Vector3(0, 0, importContext.MakeRotation(collision.m_Rotation));
+
+            go.AddComponent<SuperColliderComponent>();
+        }
+
+        private static void AddPointCollider(GameObject go, CollisionObject collision, SuperImportContext importContext)
+        {
             var xpos = importContext.MakeScalar(collision.m_Position.x);
             var ypos = importContext.MakeScalar(collision.m_Position.y);
 

--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Loaders/TilesetLoader.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Loaders/TilesetLoader.cs
@@ -341,6 +341,10 @@ namespace SuperTiled2Unity.Editor
                             collision.MakePointsFromEllipse(m_Importer.SuperImportContext.Settings.EdgesPerEllipse);
                         }
                     }
+                    else if (xObject.Element("point") != null)
+                    {
+                        collision.MakePoint();
+                    }
                     else
                     {
                         // By default, objects are rectangles


### PR DESCRIPTION
Tiled supports adding "point" objects via the collision editor.  While
these are not immediately useful when generating a collision map, they
can contain metadata that is still useful to have access to via the
SuperTile reference.