### PR TITLE
Implement unity:prefabKeepObject

### DIFF
--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Importers/TmxAssetImporter.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Importers/TmxAssetImporter.cs
@@ -430,6 +430,15 @@ namespace SuperTiled2Unity.Editor
                     {
                         objectsById[so.m_Id].BroadcastProperty(p, objectsById);
                     }
+
+                    if (so.gameObject.GetSuperPropertyValueBool(StringConstants.Unity_PrefabKeepObject, false))
+                    {
+                        var superObjectCopy = objectsById[so.m_Id].AddComponent<SuperObject>();
+                        EditorUtility.CopySerialized(so, superObjectCopy);
+
+                        var superPropsCopy = objectsById[so.m_Id].AddComponent<SuperCustomProperties>();
+                        EditorUtility.CopySerialized(props, superPropsCopy);
+                    }
                 }
             }
 

--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/StringConstants.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/StringConstants.cs
@@ -6,6 +6,7 @@
         public const string Unity_Ignore = Unity_Prefix + "ignore";
         public const string Unity_IsTrigger = Unity_Prefix + "IsTrigger";
         public const string Unity_Layer = Unity_Prefix + "layer";
+        public const string Unity_PrefabKeepObject = Unity_Prefix + "prefabKeepObject";
         public const string Unity_SortingLayer = Unity_Prefix + "SortingLayer";
         public const string Unity_SortingLayerName = Unity_Prefix + "SortingLayerName";
         public const string Unity_SortingOrder = Unity_Prefix + "SortingOrder";

--- a/docs/manual/custom-properties-importing.rst
+++ b/docs/manual/custom-properties-importing.rst
@@ -19,6 +19,7 @@ These custom properties always have a :code:`unity:` prefix so that they do not 
       * **Collision**: The colliders are not imported for the layer."
    ":code:`unity:IsTrigger`", ":code:`bool`", "Layers, Tileset, Tile, Collider, Collider Group", "Controls the :code:`isTrigger` setting of the :code:`Collider2D` object generated in the prefab. Add as a layer custom property to override all colliders for a given layer."
    ":code:`unity:layer`", ":code:`string`", "Layers, Tileset, Tile, Collider, Collider Group", "Controls which Unity phyisics layer our generated colliders are assigned. The layer name must exist in your project's Tag Manager."
+   ":code:`unity:prefabKeepObject`", ":code:`bool`", "Objects", "When set on a prefab replacement object, will retain the SuperObject and SuperCustomProperties."
    ":code:`unity:SortingLayer`", ":code:`string`", "Layers, Tile Objects", "Controls which sorting layer is assigned to the Unity :code:`Renderer` component created for your tilemaps and sprites. The sorting layer name must exist in your project's Tag Manager."
    ":code:`unity:SortingOrder`", ":code:`int`", "Layers, Tile Objects", "Controls which sorting order is applied to the Unity :code:`Renderer` component created for your tilemaps and sprites."
    ":code:`unity:Tag`", ":code:`string`", "Layers, Objects", "Controls which tag is applied to the :code:`GameObject` created for your layers and objects. The tag must exist in your project's Tag Manager."


### PR DESCRIPTION
Currently, using prefab imports nukes the SuperObject and
the SuperCustomProperties components.  While custom properties are
broadcast, it may still be desirable to allow access to arbitrary custom
properties by name at runtime.

Add a new unity attributes, unity:prefabKeepObject that on import,
checks if set on the object, and if so, creates a copy of the
SuperObject and SuperCustomProperties onto the root node of the prefab.