### PR TITLE
Add m_ObjectType, SuperCustomProperties to Objects' Colliders

### DIFF
--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/SuperColliderComponent.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/SuperColliderComponent.cs
@@ -18,6 +18,7 @@ namespace SuperTiled2Unity
         // Editor code to help us manage when we draw gizmo colliders for this component
         public List<Shape> m_PolygonShapes = new List<Shape>();
         public List<Shape> m_OutlineShapes = new List<Shape>();
+        public string m_ObjectType;
 
 #if UNITY_EDITOR
         public void AddPolygonShape(IEnumerable<Vector2> points)


### PR DESCRIPTION
Currently, there is no great way to access the collision type OR
any custom properties set on the collisions at runtime. Let's:

- Add a new public field, m_ObjectType to SuperColliderComponent.
- Add a SuperCustomProperties component to our collision subobjects.