### PR TITLE
Add DefaultSortingMode to ST2U Editor props

### DIFF
--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Importers/TiledAssetImporter.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Importers/TiledAssetImporter.cs
@@ -110,7 +110,7 @@ namespace SuperTiled2Unity.Editor
             }
         }
 
-        public void ApplyDefaultSettings()
+        virtual public void ApplyDefaultSettings()
         {
             var settings = ST2USettings.GetOrCreateST2USettings();
             m_PixelsPerUnit = settings.PixelsPerUnit;
@@ -174,7 +174,7 @@ namespace SuperTiled2Unity.Editor
             }
         }
 
-        private void WrapImportContext(AssetImportContext ctx)
+        virtual protected void WrapImportContext(AssetImportContext ctx)
         {
             var settings = ST2USettings.GetOrCreateST2USettings();
             settings.RefreshCustomObjectTypes();

--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Importers/TmxAssetImporter.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Importers/TmxAssetImporter.cs
@@ -31,7 +31,7 @@ namespace SuperTiled2Unity.Editor
         public bool TilesAsObjects { get { return m_TilesAsObjects; } }
 
         [SerializeField]
-        private SortingMode m_SortingMode = SortingMode.Stacked;
+        private SortingMode m_SortingMode;
         public SortingMode SortingMode { get { return m_SortingMode; } }
 
         [SerializeField]
@@ -43,6 +43,23 @@ namespace SuperTiled2Unity.Editor
 
         [SerializeField]
         private List<SuperTileset> m_InternalTilesets;
+
+        override public void ApplyDefaultSettings()
+        {
+            base.ApplyDefaultSettings();
+            var settings = ST2USettings.GetOrCreateST2USettings();
+            m_SortingMode = settings.SortingMode;
+            EditorUtility.SetDirty(this);
+        }
+
+        override protected void WrapImportContext(UnityEditor.AssetImporters.AssetImportContext ctx) {
+            base.WrapImportContext(ctx);
+
+            if ((int)m_SortingMode == 0)
+            {
+                m_SortingMode = SuperImportContext.Settings.SortingMode;
+            }
+        }
 
         protected override void InternalOnImportAsset()
         {

--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Settings/ST2USettings.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Settings/ST2USettings.cs
@@ -32,6 +32,10 @@ namespace SuperTiled2Unity.Editor
         public int AnimationFramerate {  get { return m_AnimationFramerate; } }
 
         [SerializeField]
+        private SortingMode m_SortingMode = SortingMode.Stacked;
+        public SortingMode SortingMode {  get { return m_SortingMode; } }
+
+        [SerializeField]
         private Material m_DefaultMaterial = null;
         public Material DefaultMaterial { get { return m_DefaultMaterial; } }
 

--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Settings/ST2USettingsProvider.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Settings/ST2USettingsProvider.cs
@@ -29,6 +29,7 @@ namespace SuperTiled2Unity.Editor
             public static readonly GUIContent m_PixelsPerUnitContent = new GUIContent("Default Pixels Per Unit", "How many pixels in the sprite correspond to one unit in the world. (Default Setting)");
             public static readonly GUIContent m_EdgesPerEllipseContent = new GUIContent("Default Edges Per Ellipse", "How many edges to use when appromixating ellipse/circle colliders. (Default Setting)");
             public static readonly GUIContent m_AnimationFramerateContent = new GUIContent("Animation Framerate", "How many frames per second for tile animations.");
+            public static readonly GUIContent m_SortingModeContent = new GUIContent("Default Sorting Mode", "Set to the default sorting mode you want to be used in newly imported .tmx files imported by SuperTiled2Unity.");
             public static readonly GUIContent m_DefaultMaterialContent = new GUIContent("Default Material", "Set to the material you want to use for sprites and tiles imported by SuperTiled2Unity. Leave empy to use built-in sprite material.");
             public static readonly GUIContent m_MaterialMatchingsContent = new GUIContent("Material Matchings", "Match these materials by Tiled Layer names.");
             public static readonly GUIContent m_ObjectTypesXmlContent = new GUIContent("Object Types Xml", "Set to an Object Types Xml file exported from Tiled Object Type Editor.");
@@ -123,6 +124,7 @@ namespace SuperTiled2Unity.Editor
         {
             var ppuProperty = m_S2TUSettingsObject.FindProperty("m_PixelsPerUnit");
             var edgesProperty = m_S2TUSettingsObject.FindProperty("m_EdgesPerEllipse");
+            var sortingModeProperty = m_S2TUSettingsObject.FindProperty("m_SortingMode");
             var materialProperty = m_S2TUSettingsObject.FindProperty("m_DefaultMaterial");
             var animationPrpoerty = m_S2TUSettingsObject.FindProperty("m_AnimationFramerate");
 
@@ -143,6 +145,9 @@ namespace SuperTiled2Unity.Editor
             {
                 edgesProperty.intValue = Mathf.Clamp(edgesProperty.intValue, 6, 256);
             }
+
+            // Default Sorting Mode
+            EditorGUILayout.PropertyField(sortingModeProperty, SettingsContent.m_SortingModeContent);
 
             // Default Material
             EditorGUILayout.PropertyField(materialProperty, SettingsContent.m_DefaultMaterialContent);

--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/SortingMode.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/SortingMode.cs
@@ -2,7 +2,7 @@
 {
     public enum SortingMode
     {
-        Stacked = 0,
-        CustomSortAxis,
+        Stacked = 10,
+        CustomSortAxis = 1,
     }
 }


### PR DESCRIPTION
Adds a "Default Sorting Mode" field to the ST2U properties panel.

We relocate Stacked from 0 to 10 so that 0 can mean "uninitialized", and get reassigned to the new value on import.
CustomSortAxis stays as 1 so we don't lose those overrides.