### PR TITLE
SuperCustomProperties and their Unity effects persist over object prefab replacement

### DIFF
--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Importers/TiledAssetImporter.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Importers/TiledAssetImporter.cs
@@ -60,6 +60,11 @@ namespace SuperTiled2Unity.Editor
             // Sort the properties alphabetically
             component.m_Properties = properties.OrderBy(p => p.m_Name).ToList();
 
+            ApplyMagicSuperCustomProperties(component);
+        }
+
+        public void ApplyMagicSuperCustomProperties(SuperCustomProperties component)
+        {
             AssignUnityTag(component);
             AssignUnityLayer(component);
         }

--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Importers/TmxAssetImporter.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Importers/TmxAssetImporter.cs
@@ -412,6 +412,15 @@ namespace SuperTiled2Unity.Editor
                     // Keep the name from Tiled.
                     instance.name = so.gameObject.name;
 
+                    // Transfer and reapply custom property magic on the instantiated prefab.
+                    var soSuperCustomProperties = so.gameObject.GetComponent<SuperCustomProperties>();
+                    if (soSuperCustomProperties != null)
+                    {
+                        var instanceSuperCustomProperties = instance.AddComponent<SuperCustomProperties>();
+                        instanceSuperCustomProperties.CopyFrom(soSuperCustomProperties);
+                        ApplyMagicSuperCustomProperties(instanceSuperCustomProperties);
+                    }
+
                     // Update bookkeeping for later custom property replacement.
                     goToDestroy.Add(so.gameObject);
                     objectsById[so.m_Id] = instance;

--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/SuperCustomProperties.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/SuperCustomProperties.cs
@@ -21,5 +21,12 @@ namespace SuperTiled2Unity
                 return name.Equals(customProperty.m_Name);
             }
         }
+
+        public void CopyFrom(SuperCustomProperties other)
+        {
+            m_Properties.Clear();
+            m_Properties.Capacity = other.m_Properties.Count;
+            m_Properties.AddRange(other.m_Properties);
+        }
     }
 }


### PR DESCRIPTION
Until now, SuperObjectProperties were lost when a Tiled object got replaced by a prefab. This also meant that the special properties `unity:tag` and `unity:layer` didn't set the tag or layer of the new prefab instances.

This pull request fixes that.