### PR TITLE
CustomTmxImporters can interpret Tiled properties of type "object"

### DIFF
--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Importers/TmxAssetImporter.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Importers/TmxAssetImporter.cs
@@ -26,6 +26,8 @@ namespace SuperTiled2Unity.Editor
         private Dictionary<uint, TilePolygonCollection> m_TilePolygonDatabase;
         private int m_NextTileAsObjectId;
 
+        private Dictionary<int, GameObject> m_ObjectsById;
+
         [SerializeField]
         private bool m_TilesAsObjects = false;
         public bool TilesAsObjects { get { return m_TilesAsObjects; } }
@@ -43,6 +45,17 @@ namespace SuperTiled2Unity.Editor
 
         [SerializeField]
         private List<SuperTileset> m_InternalTilesets;
+
+        /// <summary>
+        /// Returns the game object corresponding to a Tiled object ID.
+        /// If no such object could be found, returns null.
+        /// </summary>
+        public GameObject GetObject(int targetId)
+        {
+            return m_ObjectsById.TryGetValue(targetId, out var go)
+                ? go
+                : null;
+        }
 
         protected override void InternalOnImportAsset()
         {
@@ -395,7 +408,7 @@ namespace SuperTiled2Unity.Editor
         {
             // Should any of our objects (from Tiled) be replaced by instantiated prefabs?
             var supers = m_MapComponent.GetComponentsInChildren<SuperObject>();
-            var objectsById = supers.ToDictionary(so => so.m_Id, so => so.gameObject);
+            m_ObjectsById = supers.ToDictionary(so => so.m_Id, so => so.gameObject);
             var goToDestroy = new List<GameObject>();
 
             foreach (var so in supers)
@@ -414,7 +427,7 @@ namespace SuperTiled2Unity.Editor
 
                     // Update bookkeeping for later custom property replacement.
                     goToDestroy.Add(so.gameObject);
-                    objectsById[so.m_Id] = instance;
+                    m_ObjectsById[so.m_Id] = instance;
                 }
             }
 
@@ -428,7 +441,7 @@ namespace SuperTiled2Unity.Editor
                 {
                     foreach (var p in props.m_Properties)
                     {
-                        objectsById[so.m_Id].BroadcastProperty(p, objectsById);
+                        m_ObjectsById[so.m_Id].BroadcastProperty(p, m_ObjectsById);
                     }
                 }
             }


### PR DESCRIPTION
Added method `TmxAssetImporter.GetObject(int id)`. It enables custom TMX importers to interpret Tiled properties that are of type "object". For example, in an overridden method `CustomTmxImporter.TmxAssetImported(TmxAssetImportedArgs args)` you can do this:
```
GameObject go = ...;
int objectId = go.GetSuperPropertyValueInt("myObjectProperty", -1);
GameObject otherGo = args.AssetImporter.GetObject(objectId);
```