### PR TITLE
fix: add missing m_Type on tiles created as objects

### DIFF
--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Importers/TmxAssetImporter.TileLayer.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Importers/TmxAssetImporter.TileLayer.cs
@@ -272,6 +272,7 @@ namespace SuperTiled2Unity.Editor
                 var tileObject = goTRS.AddComponent<SuperObject>();
                 tileObject.m_Id = m_NextTileAsObjectId++;
                 tileObject.m_TiledName = string.Format("AsObject_{0}", tileObject.m_Id);
+                tileObject.m_Type = tile.m_Type;
                 tileObject.m_X = pos3.x * superMap.m_TileWidth;
                 tileObject.m_Y = -pos3.y * superMap.m_TileHeight;
                 tileObject.m_Width = tile.m_Width;


### PR DESCRIPTION
Related issue : https://github.com/Seanba/SuperTiled2Unity/issues/167