### PR TITLE
Export repeatx, repeaty as SuperImageLayer members

### DIFF
--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Loaders/SuperImageLayerLoader.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/Editor/Loaders/SuperImageLayerLoader.cs
@@ -17,7 +17,10 @@ namespace SuperTiled2Unity.Editor
 
         protected override void InternalLoadFromXml(GameObject go)
         {
-            // No extra data to load from the xml
+            var layer = go.GetComponent<SuperImageLayer>();
+
+            layer.m_RepeatX = m_Xml.GetAttributeAs("repeatx", false);
+            layer.m_RepeatY = m_Xml.GetAttributeAs("repeaty", false);
         }
     }
 }

--- a/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/SuperImageLayer.cs
+++ b/SuperTiled2Unity/Assets/SuperTiled2Unity/Scripts/SuperImageLayer.cs
@@ -4,5 +4,11 @@
     {
         [ReadOnly]
         public string m_ImageFilename;
+
+        [ReadOnly]
+        public bool m_RepeatX;
+
+        [ReadOnly]
+        public bool m_RepeatY;
     }
 }


### PR DESCRIPTION
Tiled 1.9.1 introduced repeatx and repeaty properties on image layers. Expose these from the xml to SuperImageLayer so custom importers can use them to implement repeating parallax effects.