### PR TITLE
Add support for nested class types

### DIFF
--- a/SuperTiled2Unity/Packages/com.seanba.super-tiled2unity/Editor/Extensions/GameObjectExtensions.cs
+++ b/SuperTiled2Unity/Packages/com.seanba.super-tiled2unity/Editor/Extensions/GameObjectExtensions.cs
@@ -132,7 +132,15 @@ namespace SuperTiled2Unity.Editor
         public static void BroadcastProperty(this GameObject go, CustomProperty property, Dictionary<int, GameObject> objectsById)
         {
             object objValue;
-
+			if (property.m_Type == "class")
+            {
+                var classProperty = (ClassCustomProperty)property;
+                foreach (var entry in classProperty.m_CustomProperties) 
+                {
+                    BroadcastProperty(go, entry.Value, objectsById);
+                }
+                return;
+            }
             if (property.m_Type == "bool")
             {
                 objValue = property.GetValueAsBool();

--- a/SuperTiled2Unity/Packages/com.seanba.super-tiled2unity/Editor/Loaders/CustomPropertyLoader.cs
+++ b/SuperTiled2Unity/Packages/com.seanba.super-tiled2unity/Editor/Loaders/CustomPropertyLoader.cs
@@ -31,7 +31,28 @@ namespace SuperTiled2Unity.Editor
 
             property.m_Name = xProperty.GetAttributeAs("name", "");
             property.m_Type = xProperty.GetAttributeAs("type", "string");
-
+			
+            if (property.m_Type == "class")
+            {
+                var classProperty = new ClassCustomProperty
+                {
+                    m_Name = property.m_Name,
+                    m_Type = property.m_Type
+                };
+                var elements = xProperty.Descendants();
+                if (elements != null)
+                {
+                    foreach (var element in elements)
+                    {
+                        var childProperty = LoadCustomProperty(element);
+                        if (!childProperty.IsEmpty)
+                        {
+                            classProperty.m_CustomProperties.Add(childProperty.m_Name, childProperty);
+                        }
+                    }
+                }
+                return classProperty;
+            }
             // In some cases, value may be in the default attribute
             property.m_Value = xProperty.GetAttributeAs("default", "");
 

--- a/SuperTiled2Unity/Packages/com.seanba.super-tiled2unity/Runtime/CustomProperty.cs
+++ b/SuperTiled2Unity/Packages/com.seanba.super-tiled2unity/Runtime/CustomProperty.cs
@@ -10,7 +10,26 @@ namespace SuperTiled2Unity
         public string m_Type;
         public string m_Value;
 
-        public bool IsEmpty => string.IsNullOrEmpty(m_Name);
+        public virtual CustomProperty GetCustomProperty(string key) => this;
+
+        public bool IsEmpty
+        {
+            get { return string.IsNullOrEmpty(m_Name); }
+        }
+    }
+
+    [Serializable]
+    public class ClassCustomProperty : CustomProperty
+    {
+        public Dictionary<string, CustomProperty> m_CustomProperties = new Dictionary<string, CustomProperty>();
+
+        public override CustomProperty GetCustomProperty(string key)
+        {
+            if (m_CustomProperties.TryGetValue(key, out var customProperty))
+                return customProperty;
+            return null;
+        }
+
     }
 
     // Helper extension methods
@@ -20,8 +39,13 @@ namespace SuperTiled2Unity
         {
             if (list != null)
             {
-                property = list.Find(p => String.Equals(p.m_Name, propertyName, StringComparison.OrdinalIgnoreCase));
-                return property != null;
+                property = list.Find(p => String.Equals(p.GetCustomProperty(propertyName)?.m_Name, propertyName, StringComparison.OrdinalIgnoreCase));
+                if (property != null)
+                {
+                    property = property.GetCustomProperty(propertyName);
+                    return true;
+                }
+                return false;
             }
 
             property = null;


### PR DESCRIPTION
## What?
Adds supports for nested custom type importing.

## Why?
Tiled supports nested custom objects, but when imported with SuperTiled2Unity the object is put in a property with type class and the values are lost. In place of nested custom types we could just define each field on each custom property, but it is easier to use nested custom properties.
For example 
- Character
    - CharacterDataId
    - FacingDirection
- StrollingCharacter
    - Character (this includes the fields defined above)
        - CharacterDataId
        - FacingDirection
    - WalkDistanceX
    - WalkDistanceY

Now Character can be reused in many custom types in Tiled, but this data is not imported into Unity correctly.
 
## How?
Adds a new CustomProperty type called ClassCustomProperty which contains a dictionary of values. When searching for a CustomProperty a new method GetCustomProperty is used which takes a key parameter. Regular CustomProperty ignore this parameter and return themselves, but the new ClassCustomProperty will search it's dictionary for the correct property.

## Anything Else?
I'm aware this is not an ideal solution and the code is a little ugly. I saw on other PRs you are currently changing the code and converting this to use Unity's package manager system. I was unsure if this part of the code was affected. I'm more than happy to update the PR with any feedback or to change it to match your new code changes.

I think a better solution would have been to convert CustomProperty to some kind of holder class where the key is supplied and the holder finds the customer property. This would allow things like dictionary or list properties, but I do not think Tiled supports those things and it felt like overkill here. 

I've also never used this XML library before so please let me know if there is a better way then calling Get Descendants.